### PR TITLE
Void Generation based of time and distance

### DIFF
--- a/src/main/java/voiddecay/core/VD_Settings.java
+++ b/src/main/java/voiddecay/core/VD_Settings.java
@@ -9,4 +9,5 @@ public class VD_Settings
 	public static int infectedChunks = 100;
 	public static int decayCap = 20;
 	public static boolean fastDecay = false;
+	public static boolean decayProgression = true;
 }

--- a/src/main/java/voiddecay/handlers/ConfigHandler.java
+++ b/src/main/java/voiddecay/handlers/ConfigHandler.java
@@ -23,6 +23,7 @@ public class ConfigHandler
 		VD_Settings.infectedChunks = config.getInt("Infected Chunks", Configuration.CATEGORY_GENERAL, 100, 0, 100, "What percentage of chunks are pre-infected");
 		VD_Settings.decayCap = config.getInt("Decay Cap", Configuration.CATEGORY_GENERAL, 20, 1, Integer.MAX_VALUE, "Maximum amount of blocks that can decay per second");
 		VD_Settings.fastDecay = config.getBoolean("Fast Decay", Configuration.CATEGORY_GENERAL, false, "Speeds up decay considerably at the cost of TPS latency (NOT RECOMMENDED)");
+		VD_Settings.decayProgression = config.getBoolean("Decay World Progression", Configuration.CATEGORY_GENERAL, true, "Void decay increases with world time and distance traveled from center of the world.");
 		
 		config.save();
 		

--- a/src/main/java/voiddecay/handlers/EventHandler.java
+++ b/src/main/java/voiddecay/handlers/EventHandler.java
@@ -1,5 +1,10 @@
 package voiddecay.handlers;
 
+import com.jcraft.jorbis.Block;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.MathHelper;
 import net.minecraftforge.event.terraingen.PopulateChunkEvent;
 import voiddecay.WorldGenDecay;
 import voiddecay.blocks.BlockVoidDecay;
@@ -30,7 +35,17 @@ public class EventHandler
 			int k = event.chunkZ * 16 + event.rand.nextInt(16);
 			int height = event.world.getHeightValue(i, k);
 			
-			WorldGenDecay voidGen = new WorldGenDecay(8);
+			int minDecay = 8; // sets min number of blocks for decay
+			int dayDivBy = 10; // +1 for each dayDivBy
+			int chunkDivBy = 10; // +1 for each chunkDivBy
+			
+			// Distance from center of world +1 for every 'chunkDivBy' chunks away.
+			int distModifier = Math.max((Math.max(Math.abs(event.chunkX), Math.abs(event.chunkZ))/chunkDivBy), minDecay);
+			// For every 'dayDivBy' days add +1 (grabs world time) 
+			int timeModifier = Math.max((MathHelper.floor_double(event.world.getWorldTime()/24000L)/dayDivBy)*1, 0);
+			
+			WorldGenDecay voidGen = new WorldGenDecay(distModifier + timeModifier);
+
 			voidGen.generate(event.world, event.rand, i, event.rand.nextInt(height > 1? height : 64), k);
 		}
 	}

--- a/src/main/java/voiddecay/handlers/EventHandler.java
+++ b/src/main/java/voiddecay/handlers/EventHandler.java
@@ -35,16 +35,19 @@ public class EventHandler
 			int k = event.chunkZ * 16 + event.rand.nextInt(16);
 			int height = event.world.getHeightValue(i, k);
 			
-			int minDecay = 8; // sets min number of blocks for decay
-			int dayDivBy = 10; // +1 for each dayDivBy
-			int chunkDivBy = 10; // +1 for each chunkDivBy
-			
+			int minDecay = 8; // sets min number of blocks per generation
+			int maxDecay = 110; // Sets max number of blocks per generation
+			int dayDivBy = 10; // +1 for each 'dayDivBy'
+			int chunkDivBy = 10; // +1 for each 'chunkDivBy'
+
 			// Distance from center of world +1 for every 'chunkDivBy' chunks away.
-			int distModifier = Math.max((Math.max(Math.abs(event.chunkX), Math.abs(event.chunkZ))/chunkDivBy), minDecay);
+			int distModifier = (Math.max(Math.abs(event.chunkX), Math.abs(event.chunkZ))/chunkDivBy);
 			// For every 'dayDivBy' days add +1 (grabs world time) 
 			int timeModifier = Math.max((MathHelper.floor_double(event.world.getWorldTime()/24000L)/dayDivBy)*1, 0);
-			
-			WorldGenDecay voidGen = new WorldGenDecay(distModifier + timeModifier);
+			// get number of blocks get min and max or just min if void progression false
+			int numberofblocks = VD_Settings.decayProgression ? Math.max(Math.min((distModifier + timeModifier), maxDecay), minDecay) : minDecay;
+
+			WorldGenDecay voidGen = new WorldGenDecay(numberofblocks);
 
 			voidGen.generate(event.world, event.rand, i, event.rand.nextInt(height > 1? height : 64), k);
 		}


### PR DESCRIPTION
Added new feature that increases void generation based on world time and distance from spawn.
With a couple of variables to change the void generation numbers. This will make it so as the world gets older or the player moves further and further from spawn more of the world will be decayed. Make it harder and harder to avoid the void. Now players cant just keep moving, this provides a bit more of a time limit.
